### PR TITLE
fix: ranking

### DIFF
--- a/frontend/src/pages/Ranking.vue
+++ b/frontend/src/pages/Ranking.vue
@@ -51,12 +51,12 @@ onMounted(() => {
   <!-- container -->
   <div v-if="state.records.length > 0" class="flex flex-col items-center gap-5 w-full px-4">
     <!-- separator -->
-    <TopRank v-for="(g, idx) in state.records.filter((_, i: number) => i < 3)" :key="g.group?.id" :rank="idx + 1"
+    <TopRank v-for="(g, idx) in state.records.filter((_, i: number) => i < 3)" :key="g.group?.id" :rank="g.rank"
       :class="state.group == g.group?.id ? 'bg-blue-700' : 'bg-gray-700'" :name="g.group?.id ?? ''"
       :score="g.score ?? 0" />
     <!-- top rank and normal rank separator -->
     <hr class="h-[2px] w-11/12 mx-8 text-white bg-gray-500 border-0" />
-    <RankItem v-for="(g, idx) in state.records.filter((_, i: number) => i >= 3)" :key="g.group?.id" :rank="idx + 4"
+    <RankItem v-for="(g, idx) in state.records.filter((_, i: number) => i >= 3)" :key="g.group?.id" :rank="g.rank"
       :class="state.group == g.group?.id ? 'bg-blue-700' : 'bg-gray-700'" :name="g.group?.id ?? ''"
       :score="g.score ?? 0" />
   </div>


### PR DESCRIPTION
- スコアが同一なら同じ順位として扱うように修正
  - たとえば a: 100, b: 200, c: 100 だったら b: 1, a: 2, c: 2 になる
  - また、スコアが同一のときは SubmitAt で比較をするようにした
- フロントエンドで idx を順位としていたところを rank にした